### PR TITLE
Fix parsing of consecutive floats (fixes #20)

### DIFF
--- a/demo/src/main/java/com/wnafee/vector/compat/demo/MainActivity.java
+++ b/demo/src/main/java/com/wnafee/vector/compat/demo/MainActivity.java
@@ -20,6 +20,7 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.Toast;
@@ -27,6 +28,7 @@ import android.widget.Toast;
 import com.wnafee.vector.MorphButton;
 import com.wnafee.vector.MorphButton.MorphState;
 import com.wnafee.vector.MorphButton.OnStateChangedListener;
+import com.wnafee.vector.compat.ResourcesCompat;
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class MainActivity extends ActionBarActivity {
@@ -56,6 +58,10 @@ public class MainActivity extends ActionBarActivity {
 
         LinearLayout ll = (LinearLayout) findViewById(R.id.base_view);
         ll.addView(mb);
+
+        ImageView bezierImageView = new ImageView(this);
+        bezierImageView.setImageDrawable(ResourcesCompat.getDrawable(this, R.drawable.basic_bezier));
+        ll.addView(bezierImageView);
     }
 
 

--- a/library/src/main/java/com/wnafee/vector/compat/PathParser.java
+++ b/library/src/main/java/com/wnafee/vector/compat/PathParser.java
@@ -203,6 +203,7 @@ public class PathParser {
     private static void extract(String s, int start, ExtractFloatResult result) {
         // Now looking for ' ', ',' or '-' from the start.
         int currentIndex = start;
+        boolean foundDot = false;
         boolean foundSeparator = false;
         result.mEndWithNegSign = false;
         for (; currentIndex < s.length(); currentIndex++) {
@@ -211,6 +212,18 @@ public class PathParser {
                 case ' ':
                 case ',':
                     foundSeparator = true;
+                    break;
+                case '.':
+                    if (foundDot) {
+                        // Some SVG compressors will try to be clever and include strings like
+                        // "1.5.5", which really means "1.5 0.5".
+                        // So we need to count the number of dots and consider it a separator
+                        // if we've already seen one.
+                        foundSeparator = true;
+                        currentIndex--; // because the next float needs to include the "."
+                    } else {
+                        foundDot = true;
+                    }
                     break;
                 case '-':
                     if (currentIndex != start) {

--- a/library/src/main/res/drawable/basic_bezier.xml
+++ b/library/src/main/res/drawable/basic_bezier.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:width="100dp"
+  android:height="100dp"
+  android:viewportWidth="100"
+  android:viewportHeight="100"
+  app:vc_viewportWidth="100"
+  app:vc_viewportHeight="100"
+  >
+  <path
+    android:fillColor="#000000"
+    android:pathData="s 25.0.50 0 25"
+    app:vc_fillColor="#000000"
+    app:vc_pathData="s 25.0.25 0 25"
+    />
+</vector>


### PR DESCRIPTION
This fixes the float parsing bug (#20), as well as adding an additional ImageView to the demo app in order to demonstrate the bug. Without the fix, the app will crash on Kitkat.

With the fix, you'll see a simple Bezier curve like this:

![out2](https://cloud.githubusercontent.com/assets/283842/8942062/824edab0-3541-11e5-9c21-ed704b0f5a9a.png)
